### PR TITLE
Add reusable NavBar component

### DIFF
--- a/frontend/src/presentation/components/NavBar.jsx
+++ b/frontend/src/presentation/components/NavBar.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { NavLink, useLocation } from 'react-router-dom';
+import '../styles/NavBar.css';
+
+export default function NavBar() {
+  const location = useLocation();
+  const links = [
+    { to: '/', label: 'Inicio' },
+    { to: '/puntos', label: 'Puntos' },
+    { to: '/recompensas', label: 'Recompensas' },
+    { to: '/ayuda', label: 'Ayuda' }
+  ];
+
+  return (
+    <nav className="navbar" role="navigation" aria-label="Main navigation">
+      <ul>
+        {links.map(link => (
+          <li key={link.to}>
+            <NavLink
+              to={link.to}
+              className={({ isActive }) =>
+                (isActive || location.pathname === link.to) ? 'active' : undefined
+              }
+            >
+              {link.label}
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/frontend/src/presentation/pages/Bienvenida.js
+++ b/frontend/src/presentation/pages/Bienvenida.js
@@ -1,11 +1,13 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import NavBar from "../components/NavBar";
 import { FaRecycle, FaMapMarkerAlt, FaGift } from "react-icons/fa";
 import "../styles/Bienvenida.css";
 
 export default function Bienvenida() {
   return (
     <div className="bienvenida-container">
+      <NavBar />
       <div className="bienvenida-hero">
         <FaRecycle className="bienvenida-main-icon" />
         <h1>EcoGestor Universitario</h1>

--- a/frontend/src/presentation/pages/HelpPage.jsx
+++ b/frontend/src/presentation/pages/HelpPage.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import NavBar from '../components/NavBar';
 
 export default function HelpPage() {
   return (
     <div style={{ padding: '20px' }}>
+      <NavBar />
       <h2>Ayuda / Help</h2>
       <p>Usa el menú para navegar por las secciones y registrar tu reciclaje.</p>
       <p>Para soporte adicional contáctanos en eco@univ.edu.</p>

--- a/frontend/src/presentation/pages/MapaPuntos.jsx
+++ b/frontend/src/presentation/pages/MapaPuntos.jsx
@@ -7,6 +7,7 @@ import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
 import markerIcon from "leaflet/dist/images/marker-icon.png";
 import markerShadow from "leaflet/dist/images/marker-shadow.png";
 import "../styles/MapaPuntos.css";
+import NavBar from "../components/NavBar";
 
 delete L.Icon.Default.prototype._getIconUrl;
 L.Icon.Default.mergeOptions({
@@ -23,6 +24,7 @@ const puntos = [
 export default function MapaPuntos() {
   return (
     <div className="mapa-root">
+      <NavBar />
       <div className="mapa-header">
         <span className="breadcrumb">Inicio &gt; Mapa de Puntos &gt; </span>
         <strong>Puntos Limpios - Campus Universidad Nacional</strong>

--- a/frontend/src/presentation/pages/Recompensas.jsx
+++ b/frontend/src/presentation/pages/Recompensas.jsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { FaCoffee, FaBook, FaLeaf, FaPercent } from "react-icons/fa";
 import "../styles/Recompensas.css";
+import NavBar from "../components/NavBar";
 
 export default function Recompensas() {
   return (
     <div className="recompensas-root">
+      <NavBar />
       <div className="recompensas-header">
         <span>Página Recompensas</span>
         <div className="recompensas-puntos">

--- a/frontend/src/presentation/pages/RegisterRecyclePage.jsx
+++ b/frontend/src/presentation/pages/RegisterRecyclePage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import styles from "../styles/RegisterRecyclePage.module.css";
 import ConfirmModal from "./ConfirmModal";
+import NavBar from "../components/NavBar";
 
 const pointsPerMaterial = {
   "Papel y Cartón": 5,
@@ -44,6 +45,7 @@ export default function RegisterRecyclePage() {
 
   return (
     <div className={styles.pageBg}>
+      <NavBar />
       <header className={styles.headerBar}>
         <span>Inicio</span>
         <span className={styles.chevron}>›</span>

--- a/frontend/src/presentation/styles/NavBar.css
+++ b/frontend/src/presentation/styles/NavBar.css
@@ -1,0 +1,31 @@
+.navbar {
+  background: #2d9e51;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  padding: 12px 24px;
+  font-family: 'Segoe UI', sans-serif;
+}
+
+.navbar ul {
+  list-style: none;
+  display: flex;
+  gap: 20px;
+  margin: 0;
+  padding: 0;
+}
+
+.navbar a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.navbar a.active {
+  text-decoration: underline;
+}
+
+.navbar a:focus-visible {
+  outline: 2px dashed #fff;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- add `NavBar` with main navigation links and active state highlighting
- integrate `NavBar` into Bienvenida, MapaPuntos, Recompensas, RegisterRecyclePage and HelpPage
- provide basic navigation styles

## Testing
- `npm test --silent --runTestsByPath src/App.test.js` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68754e052908832b897a4ccb34c1c2d2