### PR TITLE
Add contact form page and navigation

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,8 @@ import ProfilePage from './presentation/pages/ProfilePage';
 import HistoryPage from './presentation/pages/HistoryPage';
 import AdminPage from './presentation/pages/AdminPage';
 import HelpPage from './presentation/pages/HelpPage';
+import ContactPage from './presentation/pages/ContactPage';
+import NavBar from './presentation/components/NavBar';
 import ProtectedRoute from './ProtectedRoute';
 import { AuthProvider } from './AuthContext';
 import { LanguageProvider } from './LanguageContext';
@@ -20,6 +22,7 @@ function App() {
     <AuthProvider>
       <LanguageProvider>
         <Router basename={process.env.PUBLIC_URL}>
+          <NavBar />
           <Routes>
           <Route path="/" element={<Bienvenida />} />
           <Route path="/login" element={<LoginPage />} />
@@ -74,6 +77,7 @@ function App() {
               }
             />
             <Route path="/ayuda" element={<HelpPage />} />
+            <Route path="/contacto" element={<ContactPage />} />
           </Routes>
         </Router>
       </LanguageProvider>

--- a/frontend/src/presentation/components/NavBar.jsx
+++ b/frontend/src/presentation/components/NavBar.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import '../styles/NavBar.css';
+
+export default function NavBar() {
+  return (
+    <nav className="main-navbar">
+      <div className="nav-logo">
+        <Link to="/">EcoGestor</Link>
+      </div>
+      <ul>
+        <li><Link to="/login">Ingresar</Link></li>
+        <li><Link to="/register">Registrarse</Link></li>
+        <li><Link to="/contacto">Contacto</Link></li>
+      </ul>
+    </nav>
+  );
+}

--- a/frontend/src/presentation/pages/ContactPage.jsx
+++ b/frontend/src/presentation/pages/ContactPage.jsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import '../styles/ContactPage.css';
+
+export default function ContactPage() {
+  const [form, setForm] = useState({ nombre: '', email: '', asunto: '', mensaje: '' });
+  const [errors, setErrors] = useState({});
+  const [success, setSuccess] = useState(false);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const validate = () => {
+    const newErrors = {};
+    if (!form.nombre.trim()) newErrors.nombre = 'El nombre es obligatorio';
+    if (!form.email.trim()) newErrors.email = 'El correo es obligatorio';
+    else if (!/^\S+@\S+\.\S+$/.test(form.email)) newErrors.email = 'Correo inválido';
+    if (!form.asunto.trim()) newErrors.asunto = 'El asunto es obligatorio';
+    if (!form.mensaje.trim()) newErrors.mensaje = 'El mensaje es obligatorio';
+    return newErrors;
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const valErrors = validate();
+    if (Object.keys(valErrors).length > 0) {
+      setErrors(valErrors);
+      setSuccess(false);
+    } else {
+      setErrors({});
+      setSuccess(true);
+      setForm({ nombre: '', email: '', asunto: '', mensaje: '' });
+    }
+  };
+
+  return (
+    <div className="contact-container">
+      <h2>Contáctanos</h2>
+      <form onSubmit={handleSubmit} className="contact-form">
+        <label>Nombre</label>
+        <input name="nombre" value={form.nombre} onChange={handleChange} />
+        {errors.nombre && <span className="error">{errors.nombre}</span>}
+
+        <label>Correo Electrónico</label>
+        <input name="email" type="email" value={form.email} onChange={handleChange} />
+        {errors.email && <span className="error">{errors.email}</span>}
+
+        <label>Asunto</label>
+        <input name="asunto" value={form.asunto} onChange={handleChange} />
+        {errors.asunto && <span className="error">{errors.asunto}</span>}
+
+        <label>Mensaje</label>
+        <textarea name="mensaje" value={form.mensaje} onChange={handleChange} />
+        {errors.mensaje && <span className="error">{errors.mensaje}</span>}
+
+        {success && <div className="success">¡Mensaje enviado con éxito!</div>}
+        <button type="submit">Enviar</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/presentation/styles/ContactPage.css
+++ b/frontend/src/presentation/styles/ContactPage.css
@@ -1,0 +1,61 @@
+.contact-container {
+  max-width: 600px;
+  margin: 40px auto;
+  padding: 20px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  border-radius: 8px;
+  font-family: 'Segoe UI', sans-serif;
+}
+
+.contact-form label {
+  display: block;
+  margin-top: 12px;
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+
+.contact-form input,
+.contact-form textarea {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.contact-form textarea {
+  min-height: 100px;
+  resize: vertical;
+}
+
+.error {
+  color: #e53e3e;
+  font-size: 0.85rem;
+  margin-top: 4px;
+}
+
+.success {
+  background: #d4edda;
+  color: #155724;
+  padding: 8px;
+  border-radius: 4px;
+  margin: 12px 0;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.contact-form button {
+  margin-top: 12px;
+  padding: 10px 20px;
+  background: #2d9e51;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.contact-form button:hover {
+  background: #1e7a3c;
+}

--- a/frontend/src/presentation/styles/NavBar.css
+++ b/frontend/src/presentation/styles/NavBar.css
@@ -1,0 +1,33 @@
+.main-navbar {
+  background: #2d9e51;
+  padding: 10px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #fff;
+  font-family: 'Segoe UI', sans-serif;
+}
+
+.nav-logo a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+
+.main-navbar ul {
+  list-style: none;
+  display: flex;
+  gap: 20px;
+  margin: 0;
+  padding: 0;
+}
+
+.main-navbar a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.main-navbar a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- create `ContactPage` with simple form and validation
- add `NavBar` component with link to Contacto
- wire the new route in `App.js`
- style contact form and navbar

## Testing
- `npm test --prefix frontend --silent`

------
https://chatgpt.com/codex/tasks/task_e_68754e12a084832ba32d056ade11f41c