### PR TITLE
Add edit profile functionality

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,7 @@ import RegisterPage from './presentation/pages/RegisterPage';
 import RegisterRecyclePage from './presentation/pages/RegisterRecyclePage';
 import ProfilePage from './presentation/pages/ProfilePage';
 import HistoryPage from './presentation/pages/HistoryPage';
+import EditProfilePage from './presentation/pages/EditProfilePage';
 import AdminPage from './presentation/pages/AdminPage';
 import HelpPage from './presentation/pages/HelpPage';
 import ProtectedRoute from './ProtectedRoute';
@@ -54,6 +55,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <ProfilePage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/editar-perfil"
+            element={
+              <ProtectedRoute>
+                <EditProfilePage />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/AuthContext.js
+++ b/frontend/src/AuthContext.js
@@ -1,9 +1,5 @@
 import React, { createContext, useState, useContext, useEffect } from 'react';
-import { createClient } from '@supabase/supabase-js';
-
-const supabaseUrl =process.env.REACT_APP_SUPABASE_URL;
-const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
+import { supabase } from './utils/supabase';
 
 const AuthContext = createContext(null);
 

--- a/frontend/src/presentation/components/UserProfile.jsx
+++ b/frontend/src/presentation/components/UserProfile.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { supabase } from "../../utils/supabase";
 import "../styles/UserProfile.css";
 
 const UserProfile = () => {
   const [profile, setProfile] = useState(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     async function fetchProfile() {
@@ -45,7 +47,7 @@ const UserProfile = () => {
         <div className="profile-header">
           <span className="profile-title">Mi Perfil</span>
           <div className="profile-actions">
-            <button className="edit-btn">
+            <button className="edit-btn" onClick={() => navigate('/editar-perfil')}>
               <span className="edit-icon">&#9998;</span> Editar Perfil
             </button>
             <span className="settings-icon">&#9881;</span>

--- a/frontend/src/presentation/pages/Dashboard.jsx
+++ b/frontend/src/presentation/pages/Dashboard.jsx
@@ -111,6 +111,7 @@ export default function Dashboard() {
           {showMenu && (
             <div className="avatar-menu">
               <Link to="/perfil">Mi Perfil</Link>
+              <Link to="/editar-perfil">Editar Perfil</Link>
               <Link to="/historial">Historial</Link>
             </div>
           )}

--- a/frontend/src/presentation/pages/EditProfilePage.jsx
+++ b/frontend/src/presentation/pages/EditProfilePage.jsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '../../utils/supabase';
+
+export default function EditProfilePage() {
+  const [form, setForm] = useState({
+    nombre: '',
+    apellidos: '',
+    telefono: '',
+    facultad: '',
+    programa: '',
+    email: ''
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    async function fetchProfile() {
+      const { data: { user }, error } = await supabase.auth.getUser();
+      if (error || !user) {
+        setLoading(false);
+        return;
+      }
+      const meta = user.user_metadata || {};
+      setForm({
+        nombre: meta.nombre || '',
+        apellidos: meta.apellidos || '',
+        telefono: meta.telefono || '',
+        facultad: meta.facultad || '',
+        programa: meta.programa || '',
+        email: user.email || ''
+      });
+      setLoading(false);
+    }
+    fetchProfile();
+  }, []);
+
+  const handleChange = e => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setSaving(true);
+    setMsg('');
+    const { error } = await supabase.auth.updateUser({
+      data: {
+        nombre: form.nombre,
+        apellidos: form.apellidos,
+        telefono: form.telefono,
+        facultad: form.facultad,
+        programa: form.programa
+      }
+    });
+    if (error) {
+      setMsg(error.message || 'Error al actualizar');
+    } else {
+      setMsg('Perfil actualizado exitosamente');
+      setTimeout(() => navigate('/perfil'), 1500);
+    }
+    setSaving(false);
+  };
+
+  if (loading) {
+    return <div style={{ padding: '20px' }}>Cargando...</div>;
+  }
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <h2>Editar Perfil</h2>
+      <form onSubmit={handleSubmit} style={{ maxWidth: 500 }}>
+        <label>Nombre</label>
+        <input
+          name="nombre"
+          value={form.nombre}
+          onChange={handleChange}
+          style={{ display: 'block', width: '100%', marginBottom: 8 }}
+          required
+        />
+        <label>Apellidos</label>
+        <input
+          name="apellidos"
+          value={form.apellidos}
+          onChange={handleChange}
+          style={{ display: 'block', width: '100%', marginBottom: 8 }}
+          required
+        />
+        <label>Correo</label>
+        <input
+          value={form.email}
+          disabled
+          style={{ display: 'block', width: '100%', marginBottom: 8 }}
+        />
+        <label>Teléfono</label>
+        <input
+          name="telefono"
+          value={form.telefono}
+          onChange={handleChange}
+          style={{ display: 'block', width: '100%', marginBottom: 8 }}
+        />
+        <label>Facultad</label>
+        <input
+          name="facultad"
+          value={form.facultad}
+          onChange={handleChange}
+          style={{ display: 'block', width: '100%', marginBottom: 8 }}
+        />
+        <label>Programa</label>
+        <input
+          name="programa"
+          value={form.programa}
+          onChange={handleChange}
+          style={{ display: 'block', width: '100%', marginBottom: 8 }}
+        />
+        {msg && (
+          <div style={{ margin: '8px 0', color: msg.includes('exitosamente') ? 'green' : 'red' }}>{msg}</div>
+        )}
+        <button type="submit" disabled={saving} style={{ padding: '8px 16px' }}>
+          {saving ? 'Guardando...' : 'Guardar'}
+        </button>
+        <button type="button" onClick={() => navigate('/perfil')} style={{ marginLeft: 8, padding: '8px 16px' }}>
+          Cancelar
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/presentation/pages/LoginPage.jsx
+++ b/frontend/src/presentation/pages/LoginPage.jsx
@@ -1,11 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { createClient } from '@supabase/supabase-js';
+import { supabase } from '../../utils/supabase';
 import styles from '../styles/LoginPage.module.css';
-
-const supabaseUrl = process.env.REACT_APP_SUPABASE_URL;
-const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
 export default function LoginPage() {
   const [showResetModal, setShowResetModal] = useState(false);

--- a/frontend/src/presentation/pages/RegisterPage.jsx
+++ b/frontend/src/presentation/pages/RegisterPage.jsx
@@ -1,12 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { createClient } from '@supabase/supabase-js';
+import { supabase } from '../../utils/supabase';
 import styles from '../styles/RegisterPage.module.css';
-
-// Configura tu Supabase aquí
-const supabaseUrl =process.env.REACT_APP_SUPABASE_URL;
-const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
 export default function RegisterPage() {
   const [showPassword, setShowPassword] = useState(false);

--- a/frontend/src/utils/supabase.js
+++ b/frontend/src/utils/supabase.js
@@ -1,8 +1,10 @@
 
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = process.env.REACT_APP_SUPABASE_URL;
-const supabaseKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
+const supabaseUrl =
+  process.env.REACT_APP_SUPABASE_URL || 'http://localhost:54321';
+const supabaseKey =
+  process.env.REACT_APP_SUPABASE_ANON_KEY || 'public-anon-key';
 
 export const supabase = createClient(supabaseUrl, supabaseKey);
         


### PR DESCRIPTION
## Summary
- add `EditProfilePage` for editing user profile via Supabase
- link profile page "Editar Perfil" button to new page
- expose the page on the avatar menu
- register new route in `App.js`
- centralize Supabase client and stub defaults for tests

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68754e13cd70832b9035b7c2823f1098