### PR TITLE
Improve accessibility for login and registration forms

### DIFF
--- a/frontend/src/presentation/pages/LoginPage.jsx
+++ b/frontend/src/presentation/pages/LoginPage.jsx
@@ -95,6 +95,8 @@ export default function LoginPage() {
               value={email}
               onChange={e => setEmail(e.target.value)}
               required
+              autoFocus
+              aria-label="Correo Electrónico"
             />
           </div>
           <label className={styles.label}>Contraseña *</label>
@@ -109,6 +111,7 @@ export default function LoginPage() {
               value={password}
               onChange={e => setPassword(e.target.value)}
               required
+              aria-label="Contraseña"
             />
             <span
               className={styles.iconEye}
@@ -136,7 +139,7 @@ export default function LoginPage() {
               ¿Olvidaste tu contraseña?
             </button>
           </div>
-          {error && <div style={{ color: "red" }}>{error}</div>}
+          <div aria-live="assertive" style={{ color: 'red' }}>{error}</div>
           <button type="submit" className={styles.loginBtn} disabled={loading}>
             {loading ? 'Ingresando...' : 'Iniciar Sesión'}
           </button>
@@ -172,6 +175,7 @@ export default function LoginPage() {
                 onChange={e => setResetEmail(e.target.value)}
                 required
                 style={{ marginBottom: 8, width: '100%' }}
+                aria-label="Correo Electrónico"
               />
               <button
                 type="submit"
@@ -191,7 +195,10 @@ export default function LoginPage() {
               </button>
             </form>
             {resetMsg && (
-              <div style={{ marginTop: 8, color: resetMsg.includes('Revisa') ? 'green' : 'red', textAlign: 'center' }}>
+              <div
+                style={{ marginTop: 8, color: resetMsg.includes('Revisa') ? 'green' : 'red', textAlign: 'center' }}
+                aria-live="polite"
+              >
                 {resetMsg}
               </div>
             )}

--- a/frontend/src/presentation/pages/RegisterPage.jsx
+++ b/frontend/src/presentation/pages/RegisterPage.jsx
@@ -102,6 +102,8 @@ export default function RegisterPage() {
                 value={form.nombre}
                 onChange={handleChange}
                 required
+                autoFocus
+                aria-label="Nombre"
               />
             </div>
             <div>
@@ -113,6 +115,7 @@ export default function RegisterPage() {
                 value={form.apellidos}
                 onChange={handleChange}
                 required
+                aria-label="Apellidos"
               />
             </div>
           </div>
@@ -125,6 +128,7 @@ export default function RegisterPage() {
             value={form.email}
             onChange={handleChange}
             required
+            aria-label="Correo Institucional"
           />
           <small className={styles.note}>Debe ser tu correo institucional (@unal.edu.co)</small>
           <div className={styles.doubleInput}>
@@ -141,6 +145,7 @@ export default function RegisterPage() {
                   value={form.telefono}
                   onChange={handleChange}
                   required
+                  aria-label="Teléfono"
                 />
               </div>
             </div>
@@ -152,6 +157,7 @@ export default function RegisterPage() {
                 value={form.facultad}
                 onChange={handleChange}
                 required
+                aria-label="Facultad"
               >
                 <option value="">Seleccionar</option>
                 <option>Ingeniería</option>
@@ -167,6 +173,7 @@ export default function RegisterPage() {
             value={form.programa}
             onChange={handleChange}
             required
+            aria-label="Programa Académico"
           >
             <option value="">Seleccionar</option>
             <option>Ingeniería Ambiental</option>
@@ -187,6 +194,7 @@ export default function RegisterPage() {
               value={form.password}
               onChange={handleChange}
               required
+              aria-label="Contraseña"
             />
             <span
               className={styles.iconEye}
@@ -202,8 +210,16 @@ export default function RegisterPage() {
             </span>
           </div>
           <small className={styles.note}>Mínimo 8 caracteres, incluye mayúsculas, minúsculas y números</small>
-          {error && <div className={styles.errorMsg}>{error}</div>}
-          {success && <div className={styles.successMsg}>¡Registro exitoso! Revisa tu correo para confirmar la cuenta.</div>}
+          {error && (
+            <div className={styles.errorMsg} aria-live="assertive">
+              {error}
+            </div>
+          )}
+          {success && (
+            <div className={styles.successMsg} aria-live="polite">
+              ¡Registro exitoso! Revisa tu correo para confirmar la cuenta.
+            </div>
+          )}
           <button type="submit" className={styles.registerBtn} disabled={loading}>
             {loading ? 'Creando...' : 'Crear Cuenta'}
           </button>


### PR DESCRIPTION
## Summary
- autofocus first input in login and register pages
- label all form controls with `aria-label`
- use `aria-live` regions to announce errors

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68754e1468e0832ba06a7fce2abe8f22