### PR TITLE
Add delete confirmation modal

### DIFF
--- a/frontend/src/presentation/components/DeleteConfirm.jsx
+++ b/frontend/src/presentation/components/DeleteConfirm.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from "react";
+import styles from "./DeleteConfirm.module.css";
+
+export default function DeleteConfirm({ item, onCancel, onConfirm }) {
+  const [loading, setLoading] = useState(false);
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    try {
+      await onConfirm();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className={styles.bg}>
+      <div className={styles.card} role="dialog" aria-modal="true">
+        <h3 className={styles.title}>Confirmar Eliminación</h3>
+        <p className={styles.message}>
+          ¿Estás seguro de eliminar <b>{item}</b>?
+        </p>
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={styles.cancelBtn}
+            onClick={onCancel}
+            disabled={loading}
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            className={styles.deleteBtn}
+            onClick={handleConfirm}
+            disabled={loading}
+          >
+            {loading ? "Eliminando..." : "Eliminar"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/presentation/components/DeleteConfirm.module.css
+++ b/frontend/src/presentation/components/DeleteConfirm.module.css
@@ -1,0 +1,65 @@
+.bg {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 3100;
+}
+
+.card {
+  background: #fff;
+  border-radius: 10px;
+  padding: 24px;
+  width: 340px;
+  max-width: 90vw;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.title {
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-size: 1.2rem;
+  color: #c62828;
+  text-align: center;
+}
+
+.message {
+  color: #444;
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.cancelBtn {
+  background: #bbb;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.deleteBtn {
+  background: #e53935;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.deleteBtn:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+

--- a/frontend/src/presentation/components/RecycleHistory.jsx
+++ b/frontend/src/presentation/components/RecycleHistory.jsx
@@ -1,15 +1,17 @@
 import React, { useEffect, useState } from "react";
 import { supabase } from "../../utils/supabase";
+import DeleteConfirm from "./DeleteConfirm";
 import "../styles/RecycleHistory.css";
 
 const RecycleHistory = () => {
   const [records, setRecords] = useState([]);
+  const [toDelete, setToDelete] = useState(null);
 
   useEffect(() => {
     async function fetchRecords() {
       const { data, error } = await supabase
         .from("historial")
-        .select("id, accion, descripcion, fecha")
+        .select("id, accion, descripcion, fecha, puntos")
         .order("fecha", { ascending: false })
         .limit(10);
       if (!error && data) {
@@ -18,6 +20,13 @@ const RecycleHistory = () => {
     }
     fetchRecords();
   }, []);
+
+  const handleDelete = async (id) => {
+    const { error } = await supabase.from("historial").delete().eq("id", id);
+    if (!error) {
+      setRecords((recs) => recs.filter((r) => r.id !== id));
+    }
+  };
 
   const totalPuntos = records.reduce((acc, r) => acc + (r.puntos || 0), 0);
 
@@ -45,6 +54,13 @@ const RecycleHistory = () => {
         <div className="records-list">
           {records.map((rec) => (
             <div className="record-item" key={rec.id}>
+              <button
+                className="delete-btn"
+                onClick={() => setToDelete(rec)}
+                aria-label="Eliminar registro"
+              >
+                🗑️
+              </button>
               <div className="record-icon">&#128230;</div>
               <div className="record-info">
                 <div className="record-date">
@@ -66,6 +82,16 @@ const RecycleHistory = () => {
       <div className="recycle-footer">
         <span className="footer-title">Mi Historial de Reciclaje</span>
       </div>
+      {toDelete && (
+        <DeleteConfirm
+          item={`${toDelete.accion}`}
+          onCancel={() => setToDelete(null)}
+          onConfirm={async () => {
+            await handleDelete(toDelete.id);
+            setToDelete(null);
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/presentation/styles/RecycleHistory.css
+++ b/frontend/src/presentation/styles/RecycleHistory.css
@@ -82,6 +82,20 @@
   gap: 16px;
   position: relative;
 }
+.delete-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  border: none;
+  background: none;
+  font-size: 1.1rem;
+  cursor: pointer;
+  color: #888;
+}
+.delete-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
 .record-icon {
   font-size: 1.8rem;
   margin-top: 3px;
@@ -136,3 +150,4 @@
   font-size: 1.09rem;
   font-weight: 500;
 }
+


### PR DESCRIPTION
## Summary
- add reusable `DeleteConfirm` component and styles
- enable deleting recycle history entries with a confirmation modal
- disable delete button while request is in progress
- include `puntos` column when loading history records

## Testing
- `npm install --prefix frontend`
- `REACT_APP_SUPABASE_URL=http://localhost REACT_APP_SUPABASE_ANON_KEY=key CI=true npm test --prefix frontend --silent`


------
https://chatgpt.com/codex/tasks/task_e_68754e158f54832b86efc7ff28a487c2