### PR TITLE
Improve dashboard navbar layout

### DIFF
--- a/frontend/src/presentation/pages/Dashboard.jsx
+++ b/frontend/src/presentation/pages/Dashboard.jsx
@@ -63,30 +63,32 @@ export default function Dashboard() {
   return (
     <div className="dashboard-root">
       <nav className="dashboard-navbar">
-        <div className="dashboard-logo"><FaRecycle /> EcoGestor</div>
-        <ul>
-          <li tabIndex="0"><Link to="/puntos">{t.map}</Link></li>
-          <li tabIndex="0"><Link to="/recompensas">{t.rewards}</Link></li>
-          <li tabIndex="0"><Link to="/">{t.home}</Link></li>
-          <li tabIndex="0"><Link to="/ayuda">{t.help}</Link></li>
-          <li tabIndex="0">
-            <button onClick={() => setShowFeedback(true)} className="link-btn">
-              {t.feedback}
-            </button>
-          </li>
-          <li>
-            <button onClick={toggleLang} className="lang-btn">
-              {t.langBtn}
-            </button>
-          </li>
-        </ul>
-        <input
-          className="dashboard-search-input"
-          placeholder="Buscar secciones"
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-        />
-        <div className="dashboard-userinfo">
+        <div className="navbar-left">
+          <div className="dashboard-logo"><FaRecycle /> EcoGestor</div>
+          <ul className="dashboard-links">
+            <li tabIndex="0"><Link to="/puntos">{t.map}</Link></li>
+            <li tabIndex="0"><Link to="/recompensas">{t.rewards}</Link></li>
+            <li tabIndex="0"><Link to="/">{t.home}</Link></li>
+            <li tabIndex="0"><Link to="/ayuda">{t.help}</Link></li>
+            <li tabIndex="0">
+              <button onClick={() => setShowFeedback(true)} className="link-btn">
+                {t.feedback}
+              </button>
+            </li>
+          </ul>
+        </div>
+        <div className="navbar-center">
+          <input
+            className="dashboard-search-input"
+            placeholder="Buscar secciones"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+        </div>
+        <div className="navbar-right">
+          <button onClick={toggleLang} className="lang-btn">
+            {t.langBtn}
+          </button>
           <span className="dashboard-points">{points} pts</span>
           <span className="notif-bell" title="Notificaciones">
             <FaBell />

--- a/frontend/src/presentation/styles/Dashboard.css
+++ b/frontend/src/presentation/styles/Dashboard.css
@@ -12,6 +12,18 @@
   gap: 20px;
   padding: 12px 32px;
   border-radius: 0 0 12px 12px;
+  flex-wrap: wrap;
+}
+.navbar-left,
+.navbar-right {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+.navbar-center {
+  flex: 1 0 auto;
+  display: flex;
+  justify-content: center;
 }
 .dashboard-logo {
   font-weight: bold;
@@ -20,7 +32,7 @@
   align-items: center;
   gap: 8px;
 }
-.dashboard-navbar ul {
+.dashboard-links {
   list-style: none;
   display: flex;
   gap: 30px;
@@ -28,11 +40,11 @@
   padding: 0;
   font-weight: 500;
 }
-.dashboard-navbar li {
+.dashboard-links li {
   cursor: pointer;
   transition: 0.2s;
 }
-.dashboard-navbar li:hover {
+.dashboard-links li:hover {
   color: #aff6c4;
 }
 .lang-btn {
@@ -289,13 +301,12 @@
   justify-content: center;
 }
 .dashboard-search-input {
-  flex: 1;
-  margin: 0 20px;
+  width: 100%;
+  max-width: 350px;
   padding: 6px 10px;
   border: 1px solid #fff;
   border-radius: 6px;
   font-size: 1rem;
-  max-width: 300px;
 }
 .stat {
   background: #fff;
@@ -333,4 +344,16 @@
   font-size: 0.93rem;
   color: #444;
   margin-top: 4px;
+}
+
+@media (max-width: 600px) {
+  .navbar-center {
+    order: 3;
+    width: 100%;
+    margin-top: 8px;
+  }
+  .navbar-right {
+    flex: 1 0 auto;
+    justify-content: flex-end;
+  }
 }


### PR DESCRIPTION
## Summary
- reorganize Dashboard navbar markup
- style navbar with clearer flex containers and responsive tweaks

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687563b2dab8832bb63bcdb256693ce4