### PR TITLE
Enable back navigation and clean menu

### DIFF
--- a/frontend/src/presentation/pages/Dashboard.jsx
+++ b/frontend/src/presentation/pages/Dashboard.jsx
@@ -9,14 +9,12 @@ const translations = {
   es: {
     map: "Mapa",
     rewards: "Recompensas",
-    home: "Inicio",
     help: "Ayuda",
     langBtn: "EN",
   },
   en: {
     map: "Map",
     rewards: "Rewards",
-    home: "Home",
     help: "Help",
     langBtn: "ES",
   },
@@ -70,7 +68,6 @@ export default function Dashboard() {
                 {t.rewards}
               </button>
             </li>
-            <li tabIndex="0"><Link to="/">{t.home}</Link></li>
             <li tabIndex="0">
               <button className="link-btn" onClick={() => navigate('/ayuda')}>
                 {t.help}

--- a/frontend/src/presentation/pages/MapaPuntos.jsx
+++ b/frontend/src/presentation/pages/MapaPuntos.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { FaMapMarkerAlt } from "react-icons/fa";
+import { useNavigate } from "react-router-dom";
 import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
@@ -47,6 +48,7 @@ const puntos = [
 ];
 export default function MapaPuntos() {
   const [selected, setSelected] = useState("");
+  const navigate = useNavigate();
 
   const filtered = selected
     ? puntos.filter(p => p.material === selected)
@@ -58,7 +60,7 @@ export default function MapaPuntos() {
   return (
     <div className="mapa-root">
       <div className="mapa-header">
-        <span className="breadcrumb">Inicio &gt; Mapa de Puntos &gt; </span>
+        <button className="back-btn" onClick={() => navigate(-1)} aria-label="Volver">←</button>
         <strong>Puntos Limpios - Campus Universidad Nacional</strong>
         <button className="mapa-btn right">Mi Ubicación</button>
         <button className="mapa-btn right">Filtros</button>

--- a/frontend/src/presentation/pages/Recompensas.jsx
+++ b/frontend/src/presentation/pages/Recompensas.jsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { FaCoffee, FaBook, FaLeaf, FaPercent } from "react-icons/fa";
+import { useNavigate } from "react-router-dom";
 import "../styles/Recompensas.css";
 
 export default function Recompensas() {
+  const navigate = useNavigate();
   return (
     <div className="recompensas-root">
       <div className="recompensas-header">
-        <span>Página Recompensas</span>
+        <button className="back-btn" onClick={() => navigate(-1)} aria-label="Volver">←</button>
+        <span>Recompensas</span>
         <div className="recompensas-puntos">
           <span>1,250</span> Puntos disponibles
         </div>

--- a/frontend/src/presentation/pages/RegisterRecyclePage.jsx
+++ b/frontend/src/presentation/pages/RegisterRecyclePage.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import styles from "../styles/RegisterRecyclePage.module.css";
 import ConfirmModal from "./ConfirmModal";
 
@@ -18,6 +19,7 @@ export default function RegisterRecyclePage() {
     Vidrio: null,
   });
   const [showModal, setShowModal] = useState(false);
+  const navigate = useNavigate();
 
   const materialOptions = ["0.5 kg", "1 kg", "2+ kg"];
 
@@ -45,8 +47,7 @@ export default function RegisterRecyclePage() {
   return (
     <div className={styles.pageBg}>
       <header className={styles.headerBar}>
-        <span>Inicio</span>
-        <span className={styles.chevron}>›</span>
+        <button type="button" className={styles.backBtn} onClick={() => navigate(-1)} aria-label="Volver">←</button>
         <span className={styles.linkGreen}>Registrar Reciclaje</span>
         <span className={styles.pageTitle}>Registrar Material Reciclado</span>
         <div className={styles.pointsBox}>
@@ -285,7 +286,9 @@ export default function RegisterRecyclePage() {
           ></textarea>
         </div>
         <div className={styles.actionBtns}>
-          <button className={styles.cancelBtn}>Cancelar</button>
+          <button className={styles.cancelBtn} type="button" onClick={() => navigate(-1)}>
+            Cancelar
+          </button>
           <button className={styles.confirmBtn} onClick={handleConfirm} type="button">
             Confirmar Registro
           </button>

--- a/frontend/src/presentation/styles/MapaPuntos.css
+++ b/frontend/src/presentation/styles/MapaPuntos.css
@@ -15,6 +15,14 @@
   border-radius: 0 0 12px 12px;
   position: relative;
 }
+.back-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.2rem;
+  cursor: pointer;
+  margin-right: 6px;
+}
 .mapa-btn {
   background: #fff;
   color: #2988f7;

--- a/frontend/src/presentation/styles/Recompensas.css
+++ b/frontend/src/presentation/styles/Recompensas.css
@@ -14,6 +14,14 @@
   justify-content: space-between;
   border-radius: 0 0 16px 16px;
 }
+.back-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.3rem;
+  cursor: pointer;
+  margin-right: 12px;
+}
 .recompensas-puntos {
   background: #fff;
   color: #fd7b1f;

--- a/frontend/src/presentation/styles/RegisterRecyclePage.module.css
+++ b/frontend/src/presentation/styles/RegisterRecyclePage.module.css
@@ -13,6 +13,13 @@
   gap: 12px;
   position: relative;
 }
+.backBtn {
+  background: none;
+  border: none;
+  color: #228c39;
+  font-size: 1.3rem;
+  cursor: pointer;
+}
 .chevron {
   color: #a7a7a7;
 }


### PR DESCRIPTION
## Summary
- trim the Dashboard translations and drop the unused home link
- add back navigation to the map, rewards and register pages
- style new back buttons

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68756b985930832b82f0e53fd2cbba1a