### PR TITLE
Add dynamic puntos API and frontend map

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -9,12 +9,56 @@ app.get('/api/hello', (req, res) => {
   res.json({ message: 'Hola desde el backend!' });
 });
 
+// In-memory list of puntos limpios
+let puntos = [
+  {
+    id: 1,
+    nombre: 'Biblioteca Central',
+    material: 'Papel y Cartón',
+    estado: 'Disponible',
+    posicion: [-0.952, -80.744],
+  },
+  {
+    id: 2,
+    nombre: 'Facultad de Ingeniería',
+    material: 'Plásticos',
+    estado: '75% Lleno',
+    posicion: [-0.9535, -80.745],
+  },
+  {
+    id: 3,
+    nombre: 'Cafetería Principal',
+    material: 'Vidrio',
+    estado: 'Disponible',
+    posicion: [-0.9515, -80.746],
+  },
+  {
+    id: 4,
+    nombre: 'Centro de Estudiantes',
+    material: 'Metales',
+    estado: 'Disponible',
+    posicion: [-0.9528, -80.7445],
+  },
+];
+
 app.get('/api/puntos', (req, res) => {
-  const puntos = [
-    { id: 1, nombre: 'Biblioteca Central', estado: 'disponible' },
-    { id: 2, nombre: 'Facultad de Ingeniería', estado: '75% lleno' },
-  ];
   res.json(puntos);
+});
+
+// Add a new punto limpio
+app.post('/api/puntos', (req, res) => {
+  const nuevo = req.body;
+  const nextId = puntos.length ? Math.max(...puntos.map(p => p.id)) + 1 : 1;
+  const punto = { id: nextId, ...nuevo };
+  puntos.push(punto);
+  res.status(201).json(punto);
+});
+
+// Delete a punto limpio
+app.delete('/api/puntos/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  puntos = puntos.filter(p => p.id !== id);
+  res.json({ ok: true });
 });
 
 app.get('/api/recompensas', (req, res) => {


### PR DESCRIPTION
## Summary
- create in-memory puntos list and endpoints to add/delete
- fetch puntos from backend in map page and update markers
- allow adding and deleting puntos from the UI

## Testing
- `npm install --legacy-peer-deps` *(frontend)*
- `npm test --silent --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687574e5c8f8832b97be5bb41b077bda