### PR TITLE
Add HelpCenter design

### DIFF
--- a/frontend/src/presentation/components/HelpCenter.jsx
+++ b/frontend/src/presentation/components/HelpCenter.jsx
@@ -1,0 +1,223 @@
+import React, { useState } from "react";
+import "../styles/HelpCenter.css";
+
+const faqList = [
+  {
+    question: "¿Cómo registro que deposité material reciclable?",
+    answer:
+      "Para registrar tu reciclaje, ve a la sección 'Registrar Reciclaje', selecciona el punto limpio donde depositaste el material, elige el tipo y cantidad de material, y confirma el registro. Automáticamente se sumarán los puntos a tu cuenta.",
+  },
+  {
+    question: "¿Cómo puedo canjear mis puntos por recompensas?",
+    answer: "",
+  },
+  {
+    question: "¿Qué tipos de materiales puedo reciclar?",
+    answer: "",
+  },
+  {
+    question: "¿Cómo encuentro el punto limpio más cercano?",
+    answer: "",
+  },
+  {
+    question: "¿Qué hago si un punto limpio está lleno?",
+    answer: "",
+  },
+];
+
+export default function HelpCenter() {
+  const [openFaq, setOpenFaq] = useState(0);
+
+  return (
+    <div className="help-center-bg">
+      <div className="help-center-container">
+        {/* Header */}
+        <header className="help-header">
+          <div className="help-header__left">
+            <span className="help-header__icon">📘</span>
+            <span className="help-header__title">
+              Centro de Ayuda y Contacto
+            </span>
+          </div>
+          <div className="help-header__right">
+            <input
+              type="text"
+              className="help-search"
+              placeholder="🔍 Buscar en ayuda..."
+            />
+          </div>
+        </header>
+
+        <main>
+          <h2 className="help-title">¿Cómo podemos ayudarte?</h2>
+          <div className="help-cards">
+            <div className="help-card faq">
+              <div className="help-card__icon">📄</div>
+              <div className="help-card__text">
+                <div className="help-card__title">Preguntas Frecuentes</div>
+                <div className="help-card__desc">
+                  Encuentra respuestas rápidas a las dudas más comunes
+                </div>
+              </div>
+            </div>
+            <div className="help-card contact">
+              <div className="help-card__icon">📞</div>
+              <div className="help-card__text">
+                <div className="help-card__title">Contacto Directo</div>
+                <div className="help-card__desc">
+                  Habla directamente con nuestro equipo de soporte
+                </div>
+              </div>
+              <button className="help-card__button contact">Contactar</button>
+            </div>
+            <div className="help-card report">
+              <div className="help-card__icon">⚠️</div>
+              <div className="help-card__text">
+                <div className="help-card__title">Reportar Problema</div>
+                <div className="help-card__desc">
+                  Informa sobre problemas técnicos o incidentes
+                </div>
+              </div>
+              <button className="help-card__button report">Reportar</button>
+            </div>
+            <div className="help-card guides">
+              <div className="help-card__icon">📚</div>
+              <div className="help-card__text">
+                <div className="help-card__title">Guías y Tutoriales</div>
+                <div className="help-card__desc">
+                  Aprende a usar todas las funciones de la plataforma
+                </div>
+              </div>
+              <button className="help-card__button guides">Ver Guías</button>
+            </div>
+          </div>
+
+          {/* Preguntas frecuentes */}
+          <div className="help-faq-section">
+            <h3 className="help-faq-title">Preguntas Frecuentes</h3>
+            <div className="help-faq-list">
+              {faqList.map((faq, idx) => (
+                <div
+                  className={`help-faq-item ${openFaq === idx ? "open" : ""}`}
+                  key={faq.question}
+                >
+                  <button
+                    className="help-faq-question"
+                    onClick={() => setOpenFaq(idx === openFaq ? -1 : idx)}
+                  >
+                    {faq.question}
+                    <span className="help-faq-arrow">
+                      {openFaq === idx ? "▲" : "▼"}
+                    </span>
+                  </button>
+                  {openFaq === idx && faq.answer && (
+                    <div className="help-faq-answer">{faq.answer}</div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Formulario y contacto */}
+          <div className="help-form-contact-row">
+            {/* Formulario de Contacto */}
+            <section className="help-form">
+              <h3>Formulario de Contacto</h3>
+              <form>
+                <label>
+                  Asunto *
+                  <select>
+                    <option>Problema técnico</option>
+                    <option>Consulta general</option>
+                    <option>Otro</option>
+                  </select>
+                </label>
+                <label>
+                  Nombre Completo *
+                  <input type="text" value="Ana María González" required />
+                </label>
+                <label>
+                  Correo Electrónico *
+                  <input
+                    type="email"
+                    value="ana.gonzalez@unal.edu.co"
+                    required
+                  />
+                </label>
+                <label>
+                  Mensaje *
+                  <textarea
+                    rows={3}
+                    placeholder="Describe tu consulta o problema de manera detallada..."
+                    required
+                  ></textarea>
+                </label>
+                <div className="help-form-actions">
+                  <label className="help-form-upload">
+                    <span>📎 Adjuntar archivo</span>
+                    <input type="file" style={{ display: "none" }} />
+                    <span className="help-form-upload-hint">
+                      Opcional: capturas de pantalla, documentos
+                    </span>
+                  </label>
+                  <button type="button" className="help-form-clear">
+                    Limpiar
+                  </button>
+                  <button type="submit" className="help-form-submit">
+                    Enviar Mensaje
+                  </button>
+                </div>
+              </form>
+            </section>
+            {/* Información de Contacto */}
+            <section className="help-contact">
+              <h3>Información de Contacto</h3>
+              <div className="help-contact-hours">
+                <b className="help-contact-hours-title">
+                  <span>⏰</span> Horarios de Atención
+                </b>
+                <div className="help-contact-hours-table">
+                  <div>
+                    Lunes a Viernes: <b>8:00 AM - 6:00 PM</b>
+                  </div>
+                  <div>
+                    Sábados: <b>9:00 AM - 2:00 PM</b>
+                  </div>
+                  <div className="help-contact-hours-closed">
+                    Domingos: <b>Cerrado</b>
+                  </div>
+                </div>
+              </div>
+              <div className="help-contact-data">
+                <div>
+                  <b>Correo Electrónico</b>
+                  <div className="help-contact-link">
+                    soporte@ecogestor.unal.edu.co
+                  </div>
+                </div>
+                <div>
+                  <b>Teléfono de Soporte</b>
+                  <div>+57 (1) 316-5000 Ext. 12345</div>
+                </div>
+                <div>
+                  <b>Oficina de Sostenibilidad</b>
+                  <div>Edificio de Bienestar, Oficina 201</div>
+                </div>
+              </div>
+              <div className="help-contact-socials">
+                <b>Síguenos en Redes Sociales</b>
+                <div className="help-contact-social-icons">
+                  <span className="help-social-icon" style={{ color: "#1877F3" }}>📘</span>
+                  <span className="help-social-icon" style={{ color: "#E1306C" }}>📸</span>
+                  <span className="help-social-icon" style={{ color: "#08C9F8" }}>🐦</span>
+                  <span className="help-social-icon" style={{ color: "#25D366" }}>💬</span>
+                </div>
+              </div>
+            </section>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/presentation/pages/HelpPage.jsx
+++ b/frontend/src/presentation/pages/HelpPage.jsx
@@ -1,11 +1,6 @@
 import React from 'react';
+import HelpCenter from '../components/HelpCenter';
 
 export default function HelpPage() {
-  return (
-    <div style={{ padding: '20px' }}>
-      <h2>Ayuda / Help</h2>
-      <p>Usa el menú para navegar por las secciones y registrar tu reciclaje.</p>
-      <p>Para soporte adicional contáctanos en eco@univ.edu.</p>
-    </div>
-  );
+  return <HelpCenter />;
 }

--- a/frontend/src/presentation/styles/HelpCenter.css
+++ b/frontend/src/presentation/styles/HelpCenter.css
@@ -1,0 +1,316 @@
+body {
+  font-family: 'Segoe UI', Arial, sans-serif;
+}
+
+.help-center-bg {
+  background: #746f6e;
+  min-height: 100vh;
+  padding: 0;
+}
+
+.help-center-container {
+  max-width: 1200px;
+  background: #fff;
+  margin: 0 auto;
+  border-radius: 8px;
+  margin-top: 16px;
+  box-shadow: 0 2px 24px #0001;
+  overflow: hidden;
+}
+
+/* Header */
+.help-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #299dfc;
+  color: #fff;
+  padding: 16px 28px;
+  border-bottom: 1px solid #eee;
+}
+
+.help-header__left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.help-header__icon {
+  font-size: 1.4rem;
+  margin-right: 5px;
+}
+
+.help-header__title {
+  font-weight: 600;
+  font-size: 1.15rem;
+}
+
+.help-header__right {
+  flex-shrink: 0;
+}
+.help-search {
+  border: none;
+  border-radius: 18px;
+  padding: 8px 18px;
+  font-size: 1rem;
+  outline: none;
+  width: 210px;
+  background: #fff;
+  color: #444;
+}
+
+/* Título */
+.help-title {
+  font-size: 1.55rem;
+  font-weight: 700;
+  color: #265cb9;
+  margin: 30px 0 16px 32px;
+}
+
+/* Cards */
+.help-cards {
+  display: flex;
+  gap: 22px;
+  margin: 0 28px 18px 28px;
+  flex-wrap: wrap;
+}
+
+.help-card {
+  flex: 1 1 170px;
+  min-width: 210px;
+  background: #f2f9fe;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  padding: 18px 16px 14px 16px;
+  align-items: flex-start;
+  box-shadow: 0 1px 8px #0001;
+  position: relative;
+  margin-bottom: 12px;
+}
+.help-card__icon {
+  font-size: 2rem;
+  margin-bottom: 6px;
+}
+.help-card__title {
+  font-size: 1.08rem;
+  font-weight: bold;
+  color: #265cb9;
+  margin-bottom: 3px;
+}
+.help-card__desc {
+  font-size: 0.97rem;
+  color: #555;
+}
+
+.help-card.contact {
+  background: #e8f7e5;
+}
+.help-card.report {
+  background: #fff7e1;
+}
+.help-card.guides {
+  background: #f3ebfa;
+}
+
+.help-card__button {
+  border: none;
+  border-radius: 6px;
+  padding: 7px 22px;
+  font-weight: 600;
+  font-size: 1rem;
+  margin-top: 10px;
+  cursor: pointer;
+}
+.help-card__button.contact {
+  background: #23c151;
+  color: #fff;
+}
+.help-card__button.report {
+  background: #ff9700;
+  color: #fff;
+}
+.help-card__button.guides {
+  background: #9919be;
+  color: #fff;
+}
+
+/* Preguntas frecuentes */
+.help-faq-section {
+  margin: 34px 32px 10px 32px;
+}
+.help-faq-title {
+  font-size: 1.22rem;
+  color: #265cb9;
+  font-weight: bold;
+  margin-bottom: 6px;
+}
+.help-faq-list {
+  border-radius: 8px;
+  background: #f8fafb;
+  box-shadow: 0 1px 8px #0001;
+  padding: 3px 0;
+}
+.help-faq-item {
+  border-bottom: 1px solid #eee;
+}
+.help-faq-item:last-child {
+  border-bottom: none;
+}
+.help-faq-question {
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 17px 16px;
+  text-align: left;
+  font-size: 1.04rem;
+  color: #2d3540;
+  font-weight: 500;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.help-faq-answer {
+  background: #f4faff;
+  color: #3a4a58;
+  font-size: 0.98rem;
+  padding: 10px 22px 18px 22px;
+  border-radius: 0 0 8px 8px;
+  animation: faqfade 0.3s;
+}
+@keyframes faqfade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.help-faq-arrow {
+  font-size: 1.1rem;
+  color: #299dfc;
+}
+
+/* Formulario y Contacto */
+.help-form-contact-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 28px;
+  margin: 38px 32px 38px 32px;
+}
+.help-form, .help-contact {
+  flex: 1 1 330px;
+  background: #f8fafb;
+  border-radius: 12px;
+  box-shadow: 0 1px 8px #0001;
+  padding: 28px 22px 18px 22px;
+  min-width: 330px;
+  margin-bottom: 12px;
+}
+
+.help-form h3, .help-contact h3 {
+  font-size: 1.13rem;
+  color: #265cb9;
+  font-weight: bold;
+  margin-bottom: 13px;
+}
+.help-form form label {
+  display: block;
+  font-size: 0.97rem;
+  font-weight: 500;
+  margin-bottom: 8px;
+  color: #313a4d;
+}
+.help-form select, .help-form input, .help-form textarea {
+  width: 100%;
+  margin-top: 4px;
+  margin-bottom: 15px;
+  padding: 7px 9px;
+  border-radius: 7px;
+  border: 1px solid #b8c1cd;
+  font-size: 1rem;
+  background: #fff;
+  color: #30333a;
+  resize: vertical;
+}
+.help-form textarea {
+  min-height: 70px;
+}
+.help-form-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.help-form-upload {
+  font-size: 0.98rem;
+  color: #5c5c5c;
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+}
+.help-form-upload-hint {
+  font-size: 0.89rem;
+  color: #9fa4ac;
+}
+.help-form-clear {
+  background: #f0f1f3;
+  color: #323842;
+  border: none;
+  padding: 8px 15px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.98rem;
+}
+.help-form-submit {
+  background: #299dfc;
+  color: #fff;
+  border: none;
+  padding: 8px 17px;
+  border-radius: 7px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+/* Info de contacto */
+.help-contact-hours {
+  margin-bottom: 19px;
+}
+.help-contact-hours-title {
+  color: #265cb9;
+  font-size: 1.03rem;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.help-contact-hours-table {
+  margin-left: 12px;
+  font-size: 0.99rem;
+}
+.help-contact-hours-closed b {
+  color: #f55;
+}
+.help-contact-data {
+  margin-bottom: 15px;
+  font-size: 1rem;
+}
+.help-contact-link {
+  color: #299dfc;
+  font-size: 1rem;
+  cursor: pointer;
+}
+.help-contact-socials {
+  font-size: 0.99rem;
+}
+.help-contact-social-icons {
+  display: flex;
+  gap: 12px;
+  margin-top: 7px;
+}
+.help-social-icon {
+  font-size: 1.35rem;
+  cursor: pointer;
+}
+@media (max-width: 950px) {
+  .help-cards { flex-direction: column; }
+  .help-form-contact-row { flex-direction: column; }
+}
+


### PR DESCRIPTION
## Summary
- introduce new HelpCenter component with FAQ and contact form
- style HelpCenter page
- show HelpCenter when navigating to `/ayuda`

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687575016530832baefea285e68b7bc0