### PR TITLE
Add create point button on map

### DIFF
--- a/frontend/src/presentation/pages/MapaPuntos.jsx
+++ b/frontend/src/presentation/pages/MapaPuntos.jsx
@@ -19,6 +19,7 @@ L.Icon.Default.mergeOptions({
 export default function MapaPuntos() {
   const [puntos, setPuntos] = useState([]);
   const [selected, setSelected] = useState("");
+  const [creating, setCreating] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -31,7 +32,9 @@ export default function MapaPuntos() {
   const [newPoint, setNewPoint] = useState(null);
 
   const handleMapClick = e => {
+    if (!creating) return;
     setNewPoint({ lat: e.latlng.lat, lng: e.latlng.lng, nombre: "", material: "" });
+    setCreating(false);
   };
 
   const handleChange = e => {
@@ -74,6 +77,14 @@ export default function MapaPuntos() {
       <div className="mapa-header">
         <button className="back-btn" onClick={() => navigate(-1)} aria-label="Volver">←</button>
         <strong>Puntos Limpios - Campus Universidad Nacional</strong>
+        {creating && <span className="breadcrumb">Seleccione un punto en el mapa</span>}
+        <button
+          className="mapa-btn"
+          onClick={() => setCreating(true)}
+          disabled={creating || newPoint}
+        >
+          Crear Punto
+        </button>
         <button className="mapa-btn right">Mi Ubicación</button>
         <button className="mapa-btn right">Filtros</button>
       </div>
@@ -160,17 +171,31 @@ export default function MapaPuntos() {
                       />
                     </div>
                     <div>
-                      <input
-                        type="text"
+                      <select
                         name="material"
-                        placeholder="Material"
                         value={newPoint.material}
                         onChange={handleChange}
                         required
-                      />
+                      >
+                        <option value="" disabled>
+                          Seleccionar material
+                        </option>
+                        {['Papel y Cartón', 'Plásticos', 'Vidrio', 'Metales'].map(m => (
+                          <option key={m} value={m}>
+                            {m}
+                          </option>
+                        ))}
+                      </select>
                     </div>
                     <div style={{ marginTop: '6px', textAlign: 'right' }}>
-                      <button type="button" className="mapa-btn" onClick={() => setNewPoint(null)}>
+                      <button
+                        type="button"
+                        className="mapa-btn"
+                        onClick={() => {
+                          setNewPoint(null);
+                          setCreating(false);
+                        }}
+                      >
                         Cancelar
                       </button>
                       <button type="submit" className="mapa-btn" style={{ marginLeft: '6px' }}>

--- a/frontend/src/presentation/styles/MapaPuntos.css
+++ b/frontend/src/presentation/styles/MapaPuntos.css
@@ -139,3 +139,11 @@
   border-radius: 4px;
   font-size: 0.9rem;
 }
+.popup-form select {
+  width: 100%;
+  padding: 4px;
+  margin-top: 4px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- allow entering point creation mode with a new button
- prompt to select a location while creating
- show dropdown to pick material category

## Testing
- `npm test --silent <<<"q"`

------
https://chatgpt.com/codex/tasks/task_e_687579141f84832baa9676afd86b1930