### PR TITLE
Combine profile pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,9 +7,7 @@ import Recompensas from './presentation/pages/Recompensas';
 import LoginPage from './presentation/pages/LoginPage';
 import RegisterPage from './presentation/pages/RegisterPage';
 import RegisterRecyclePage from './presentation/pages/RegisterRecyclePage';
-import ProfilePage from './presentation/pages/ProfilePage';
-import HistoryPage from './presentation/pages/HistoryPage';
-import EditProfilePage from './presentation/pages/EditProfilePage';
+import AccountPage from './presentation/pages/AccountPage';
 import AdminPage from './presentation/pages/AdminPage';
 import HelpPage from './presentation/pages/HelpPage';
 import ContactPage from './presentation/pages/ContactPage';
@@ -55,7 +53,7 @@ function App() {
             path="/perfil"
             element={
               <ProtectedRoute>
-                <ProfilePage />
+                <AccountPage />
               </ProtectedRoute>
             }
           />
@@ -63,7 +61,7 @@ function App() {
             path="/editar-perfil"
             element={
               <ProtectedRoute>
-                <EditProfilePage />
+                <AccountPage />
               </ProtectedRoute>
             }
           />
@@ -71,7 +69,7 @@ function App() {
             path="/historial"
             element={
               <ProtectedRoute>
-                <HistoryPage />
+                <AccountPage />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/presentation/components/EditProfileForm.jsx
+++ b/frontend/src/presentation/components/EditProfileForm.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { supabase } from '../../utils/supabase';
+import { useNavigate } from 'react-router-dom';
+import '../styles/EditProfileForm.css';
 
-export default function EditProfilePage() {
+export default function EditProfileForm() {
   const [form, setForm] = useState({
     nombre: '',
     apellidos: '',
@@ -52,7 +53,7 @@ export default function EditProfilePage() {
         apellidos: form.apellidos,
         telefono: form.telefono,
         facultad: form.facultad,
-        programa: form.programa
+        programa: form.programa,
       }
     });
     if (error) {
@@ -65,19 +66,18 @@ export default function EditProfilePage() {
   };
 
   if (loading) {
-    return <div style={{ padding: '20px' }}>Cargando...</div>;
+    return <div className="editprofile-loading">Cargando...</div>;
   }
 
   return (
-    <div style={{ padding: '20px' }}>
+    <div className="editprofile-form-wrapper" id="editar">
       <h2>Editar Perfil</h2>
-      <form onSubmit={handleSubmit} style={{ maxWidth: 500 }}>
+      <form onSubmit={handleSubmit} className="editprofile-form">
         <label>Nombre</label>
         <input
           name="nombre"
           value={form.nombre}
           onChange={handleChange}
-          style={{ display: 'block', width: '100%', marginBottom: 8 }}
           required
         />
         <label>Apellidos</label>
@@ -85,45 +85,39 @@ export default function EditProfilePage() {
           name="apellidos"
           value={form.apellidos}
           onChange={handleChange}
-          style={{ display: 'block', width: '100%', marginBottom: 8 }}
           required
         />
         <label>Correo</label>
-        <input
-          value={form.email}
-          disabled
-          style={{ display: 'block', width: '100%', marginBottom: 8 }}
-        />
+        <input value={form.email} disabled />
         <label>Teléfono</label>
         <input
           name="telefono"
           value={form.telefono}
           onChange={handleChange}
-          style={{ display: 'block', width: '100%', marginBottom: 8 }}
         />
         <label>Facultad</label>
         <input
           name="facultad"
           value={form.facultad}
           onChange={handleChange}
-          style={{ display: 'block', width: '100%', marginBottom: 8 }}
         />
         <label>Programa</label>
         <input
           name="programa"
           value={form.programa}
           onChange={handleChange}
-          style={{ display: 'block', width: '100%', marginBottom: 8 }}
         />
         {msg && (
-          <div style={{ margin: '8px 0', color: msg.includes('exitosamente') ? 'green' : 'red' }}>{msg}</div>
+          <div className={msg.includes('exitosamente') ? 'msg-success' : 'msg-error'}>{msg}</div>
         )}
-        <button type="submit" disabled={saving} style={{ padding: '8px 16px' }}>
-          {saving ? 'Guardando...' : 'Guardar'}
-        </button>
-        <button type="button" onClick={() => navigate('/perfil')} style={{ marginLeft: 8, padding: '8px 16px' }}>
-          Cancelar
-        </button>
+        <div className="editprofile-actions">
+          <button type="submit" disabled={saving}>
+            {saving ? 'Guardando...' : 'Guardar'}
+          </button>
+          <button type="button" onClick={() => navigate('/perfil')} className="cancel-btn">
+            Cancelar
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/frontend/src/presentation/components/UserProfile.jsx
+++ b/frontend/src/presentation/components/UserProfile.jsx
@@ -47,7 +47,7 @@ const UserProfile = () => {
         <div className="profile-header">
           <span className="profile-title">Mi Perfil</span>
           <div className="profile-actions">
-            <button className="edit-btn" onClick={() => navigate('/editar-perfil')}>
+            <button className="edit-btn" onClick={() => navigate('/perfil#editar')}>
               <span className="edit-icon">&#9998;</span> Editar Perfil
             </button>
             <span className="settings-icon">&#9881;</span>

--- a/frontend/src/presentation/pages/AccountPage.jsx
+++ b/frontend/src/presentation/pages/AccountPage.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import UserProfile from '../components/UserProfile';
+import EditProfileForm from '../components/EditProfileForm';
+import RecycleHistory from '../components/RecycleHistory';
+import '../styles/AccountPage.css';
+
+export default function AccountPage() {
+  return (
+    <div className="account-bg">
+      <div className="account-section">
+        <UserProfile />
+      </div>
+      <div className="account-section">
+        <EditProfileForm />
+      </div>
+      <div className="account-section">
+        <RecycleHistory />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/presentation/pages/Dashboard.jsx
+++ b/frontend/src/presentation/pages/Dashboard.jsx
@@ -95,8 +95,6 @@ export default function Dashboard() {
           {showMenu && (
             <div className="avatar-menu">
               <Link to="/perfil">Mi Perfil</Link>
-              <Link to="/editar-perfil">Editar Perfil</Link>
-              <Link to="/historial">Historial</Link>
             </div>
           )}
         </div>

--- a/frontend/src/presentation/pages/HistoryPage.jsx
+++ b/frontend/src/presentation/pages/HistoryPage.jsx
@@ -1,6 +1,0 @@
-import React from 'react';
-import RecycleHistory from '../components/RecycleHistory';
-
-export default function HistoryPage() {
-  return <RecycleHistory />;
-}

--- a/frontend/src/presentation/pages/ProfilePage.jsx
+++ b/frontend/src/presentation/pages/ProfilePage.jsx
@@ -1,6 +1,0 @@
-import React from 'react';
-import UserProfile from '../components/UserProfile';
-
-export default function ProfilePage() {
-  return <UserProfile />;
-}

--- a/frontend/src/presentation/styles/AccountPage.css
+++ b/frontend/src/presentation/styles/AccountPage.css
@@ -1,0 +1,16 @@
+.account-bg {
+  background: #ececec;
+  min-height: 100vh;
+  padding: 20px 0;
+}
+.account-section {
+  margin-bottom: 20px;
+}
+@media (min-width: 768px) {
+  .account-section {
+    width: 90%;
+    max-width: 800px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}

--- a/frontend/src/presentation/styles/EditProfileForm.css
+++ b/frontend/src/presentation/styles/EditProfileForm.css
@@ -1,0 +1,42 @@
+.editprofile-form-wrapper {
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+  max-width: 800px;
+  margin: 0 auto 20px auto;
+}
+.editprofile-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.editprofile-form input {
+  padding: 6px 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.editprofile-actions {
+  margin-top: 10px;
+  display: flex;
+  gap: 8px;
+}
+.editprofile-actions button {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.editprofile-actions .cancel-btn {
+  background: #ccc;
+  color: #000;
+}
+.msg-success {
+  color: green;
+}
+.msg-error {
+  color: red;
+}
+.editprofile-loading {
+  padding: 20px;
+}

--- a/frontend/src/presentation/styles/RecycleHistory.css
+++ b/frontend/src/presentation/styles/RecycleHistory.css
@@ -1,11 +1,11 @@
 .recycle-bg {
-  background: #6f6767;
-  min-height: 100vh;
+  background: #ececec;
   padding: 24px 0;
   font-family: "Segoe UI", Arial, sans-serif;
 }
 .recycle-container {
-  width: 800px;
+  width: 100%;
+  max-width: 800px;
   margin: 0 auto;
   background: #fff;
   border-radius: 10px 10px 0 0;
@@ -135,7 +135,8 @@
 }
 
 .recycle-footer {
-  width: 800px;
+  width: 100%;
+  max-width: 800px;
   margin: 0 auto;
   background: #48a03f;
   border-radius: 0 0 10px 10px;

--- a/frontend/src/presentation/styles/UserProfile.css
+++ b/frontend/src/presentation/styles/UserProfile.css
@@ -1,11 +1,11 @@
 .profile-bg {
-  background: #6f6767;
-  min-height: 100vh;
-  padding: 20px;
+  background: #ececec;
+  padding: 20px 0;
 }
 .profile-container {
   margin: 0 auto;
-  width: 800px;
+  width: 100%;
+  max-width: 800px;
   border: 3px solid #48a03f;
   border-radius: 8px;
   background: #fff;


### PR DESCRIPTION
## Summary
- replace separate profile/edit/history pages with new `AccountPage`
- use new `EditProfileForm` component and updated user profile routing
- adjust Dashboard menu to a single profile link
- tweak styles for responsiveness

## Testing
- `npm test --silent --run`

------
https://chatgpt.com/codex/tasks/task_e_6875795af590832b84f2e3917bfe2e39