### PR TITLE
Add help and report panels

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,7 @@ import EditProfilePage from './presentation/pages/EditProfilePage';
 import AdminPage from './presentation/pages/AdminPage';
 import HelpPage from './presentation/pages/HelpPage';
 import ContactPage from './presentation/pages/ContactPage';
+import Reportes from './presentation/pages/Reportes';
 import ProtectedRoute from './ProtectedRoute';
 import { AuthProvider } from './AuthContext';
 import { LanguageProvider } from './LanguageContext';
@@ -84,6 +85,7 @@ function App() {
               }
             />
             <Route path="/ayuda" element={<HelpPage />} />
+            <Route path="/reportes" element={<Reportes />} />
             <Route path="/contacto" element={<ContactPage />} />
           </Routes>
         </Router>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -18,5 +18,6 @@
   "dashboard_register": "Register",
   "dashboard_rewards": "Rewards",
   "dashboard_help": "Help",
+  "dashboard_reports": "Reports",
   "lang_button": "ES"
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -18,5 +18,6 @@
   "dashboard_register": "Registrar",
   "dashboard_rewards": "Recompensas",
   "dashboard_help": "Ayuda",
+  "dashboard_reports": "Reportes",
   "lang_button": "EN"
 }

--- a/frontend/src/presentation/pages/Dashboard.jsx
+++ b/frontend/src/presentation/pages/Dashboard.jsx
@@ -1,6 +1,14 @@
 import React, { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { FaRecycle, FaGift, FaMapMarkerAlt, FaBell } from "react-icons/fa";
+import {
+  FaRecycle,
+  FaGift,
+  FaMapMarkerAlt,
+  FaBell,
+  FaQuestionCircle,
+  FaExclamationTriangle,
+  FaClock,
+} from "react-icons/fa";
 import { supabase } from "../../utils/supabase";
 import { useLang } from "../../LanguageContext";
 import { useTranslation } from "react-i18next";
@@ -63,6 +71,11 @@ export default function Dashboard() {
               <li tabIndex="0">
                 <button className="link-btn" onClick={() => navigate('/ayuda')}>
                   {t('dashboard_help')}
+                </button>
+              </li>
+              <li tabIndex="0">
+                <button className="link-btn" onClick={() => navigate('/reportes')}>
+                  {t('dashboard_reports')}
                 </button>
               </li>
             </ul>
@@ -138,11 +151,42 @@ export default function Dashboard() {
               <span className="badge orange">23 disponibles</span>
             </div>
             <p>Canjea tus puntos por descuentos en cafeterías, papelería, libros y productos sostenibles</p>
-            <Link className="orange-btn" to="/recompensas">
-              <FaGift /> Explorar Premios
+          <Link className="orange-btn" to="/recompensas">
+            <FaGift /> Explorar Premios
+          </Link>
+        </div>
+        </div>
+
+        <div className="dashboard-main-panels">
+          <div className="dashboard-panel help">
+            <div className="panel-header">
+              <span>Ayuda</span>
+            </div>
+            <p>Accede al centro de ayuda para resolver dudas sobre la plataforma</p>
+            <Link className="blue-btn" to="/ayuda">
+              <FaQuestionCircle /> Ver Ayuda
             </Link>
           </div>
+          <div className="dashboard-panel reports">
+            <div className="panel-header">
+              <span>Reportes</span>
+            </div>
+            <p>Envía reportes o revisa problemas comunicados por la comunidad</p>
+            <Link className="green-btn" to="/reportes">
+              <FaExclamationTriangle /> Ir a Reportes
+            </Link>
+          </div>
+          <div className="dashboard-panel upcoming">
+            <div className="panel-header">
+              <span>Próximamente</span>
+            </div>
+            <p>Estamos trabajando en nuevas funcionalidades que verás pronto</p>
+            <div className="orange-btn" style={{ pointerEvents: 'none', opacity: 0.6 }}>
+              <FaClock /> Próximamente
+            </div>
+          </div>
         </div>
+
         <div className="dashboard-activity">
           <h3>Tu Actividad Reciente</h3>
           <ul>

--- a/frontend/src/presentation/pages/Reportes.jsx
+++ b/frontend/src/presentation/pages/Reportes.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import "../styles/Reportes.css";
+import { useNavigate } from "react-router-dom";
+
+export default function Reportes() {
+  const navigate = useNavigate();
+  return (
+    <div className="reportes-root">
+      <div className="reportes-header">
+        <button className="back-btn" onClick={() => navigate(-1)} aria-label="Volver">←</button>
+        <span>Reportes</span>
+      </div>
+      <div className="reportes-content">
+        <p>Aquí podrás ver y enviar reportes sobre problemas o incidencias relacionadas con los puntos de reciclaje.</p>
+        <p>Próximamente se añadirán más funcionalidades.</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/presentation/styles/Reportes.css
+++ b/frontend/src/presentation/styles/Reportes.css
@@ -1,0 +1,24 @@
+.reportes-root {
+  padding: 20px;
+  font-family: 'Segoe UI', sans-serif;
+}
+.reportes-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  font-size: 1.3rem;
+  font-weight: bold;
+}
+.back-btn {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+.reportes-content {
+  background: #fff;
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(44, 146, 82, 0.04);
+}


### PR DESCRIPTION
## Summary
- add Reportes page
- add Reportes route
- add translation strings for dashboard_reports
- extend navbar with Reportes item
- show help, reportes and upcoming panels in dashboard

## Testing
- `npm install --legacy-peer-deps`
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_68757b278fa8832ba4253caa0da2a9ed