### PR TITLE
Add back button to help page

### DIFF
--- a/frontend/src/presentation/components/HelpCenter.jsx
+++ b/frontend/src/presentation/components/HelpCenter.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   FaBook,
   FaSearch,
@@ -42,12 +43,20 @@ const faqList = [
 export default function HelpCenter() {
   const [openFaq, setOpenFaq] = useState(0);
   const [showContactInfo, setShowContactInfo] = useState(false);
+  const navigate = useNavigate();
 
   return (
     <div className="help-center-bg">
       <div className="help-center-container">
         {/* Header */}
         <header className="help-header">
+          <button
+            className="back-btn"
+            onClick={() => navigate(-1)}
+            aria-label="Volver"
+          >
+            ←
+          </button>
           <div className="help-header__left">
             <FaBook className="help-header__icon" />
             <span className="help-header__title">

--- a/frontend/src/presentation/styles/HelpCenter.css
+++ b/frontend/src/presentation/styles/HelpCenter.css
@@ -28,6 +28,14 @@ body {
   padding: 16px 28px;
   border-bottom: 1px solid #eee;
 }
+.back-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.2rem;
+  cursor: pointer;
+  margin-right: 8px;
+}
 
 .help-header__left {
   display: flex;


### PR DESCRIPTION
## Summary
- add navigation hook and back button in HelpCenter
- style new back button

## Testing
- `npm install --legacy-peer-deps`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68757bed51b4832b9aa84ddb5f16d2f5