### PR TITLE
Implement edit button for map points

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -61,6 +61,19 @@ app.delete('/api/puntos/:id', (req, res) => {
   res.json({ ok: true });
 });
 
+// Update a punto limpio
+app.put('/api/puntos/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const updates = req.body;
+  let punto = puntos.find(p => p.id === id);
+  if (!punto) {
+    return res.status(404).json({ error: 'Punto no encontrado' });
+  }
+  punto = { ...punto, ...updates };
+  puntos = puntos.map(p => (p.id === id ? punto : p));
+  res.json(punto);
+});
+
 app.get('/api/recompensas', (req, res) => {
   const recompensas = [
     { id: 1, nombre: 'Café Gratis', costo: 150 },

--- a/frontend/src/presentation/pages/MapaPuntos.jsx
+++ b/frontend/src/presentation/pages/MapaPuntos.jsx
@@ -65,6 +65,22 @@ export default function MapaPuntos() {
     setPuntos(prev => prev.filter(p => p.id !== id));
   };
 
+  const editPunto = async p => {
+    const nombre = window.prompt("Nuevo nombre", p.nombre);
+    if (nombre === null) return;
+    const material = window.prompt("Nuevo material", p.material);
+    if (material === null) return;
+    const res = await fetch(`/api/puntos/${p.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ nombre, material }),
+    });
+    if (res.ok) {
+      const actualizado = await res.json();
+      setPuntos(prev => prev.map(pt => (pt.id === p.id ? actualizado : pt)));
+    }
+  };
+
   const filtered = selected
     ? puntos.filter(p => p.material === selected)
     : puntos;
@@ -132,9 +148,18 @@ export default function MapaPuntos() {
                 >
                   {p.estado}
                 </span>
-                <button className="mapa-btn" onClick={() => deletePunto(p.id)}>
-                  Eliminar
-                </button>
+                <div>
+                  <button
+                    className="mapa-btn"
+                    onClick={() => editPunto(p)}
+                    style={{ marginRight: '6px' }}
+                  >
+                    Editar
+                  </button>
+                  <button className="mapa-btn" onClick={() => deletePunto(p.id)}>
+                    Eliminar
+                  </button>
+                </div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- support updating points in backend API
- allow editing a "punto limpio" from map sidebar

## Testing
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_68758a5811a4832b8e9d2ab11e367c86