### PR TITLE
Add dark mode and search to dashboard

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,12 +15,14 @@ import Reportes from './presentation/pages/Reportes';
 import ProtectedRoute from './ProtectedRoute';
 import { AuthProvider } from './AuthContext';
 import { LanguageProvider } from './LanguageContext';
+import { ThemeProvider } from './ThemeContext';
 
 function App() {
   return (
     <AuthProvider>
       <LanguageProvider>
-        <Router basename={process.env.PUBLIC_URL}>
+        <ThemeProvider>
+          <Router basename={process.env.PUBLIC_URL}>
           <Routes>
           <Route path="/" element={<Bienvenida />} />
           <Route path="/login" element={<LoginPage />} />
@@ -87,6 +89,7 @@ function App() {
             <Route path="/contacto" element={<ContactPage />} />
           </Routes>
         </Router>
+        </ThemeProvider>
       </LanguageProvider>
     </AuthProvider>
   );

--- a/frontend/src/ThemeContext.js
+++ b/frontend/src/ThemeContext.js
@@ -1,0 +1,20 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext({ dark: false, toggleDark: () => {} });
+
+export function ThemeProvider({ children }) {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    document.body.classList.toggle('dark', dark);
+  }, [dark]);
+  const toggleDark = () => setDark(d => !d);
+  return (
+    <ThemeContext.Provider value={{ dark, toggleDark }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,3 +11,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+body.dark {
+  background: #2b2b2b;
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -19,5 +19,6 @@
   "dashboard_rewards": "Rewards",
   "dashboard_help": "Help",
   "dashboard_reports": "Reports",
-  "lang_button": "ES"
+  "lang_button": "ES",
+  "search_placeholder": "Search..."
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -19,5 +19,6 @@
   "dashboard_rewards": "Recompensas",
   "dashboard_help": "Ayuda",
   "dashboard_reports": "Reportes",
-  "lang_button": "EN"
+  "lang_button": "EN",
+  "search_placeholder": "Buscar..."
 }

--- a/frontend/src/presentation/pages/Dashboard.jsx
+++ b/frontend/src/presentation/pages/Dashboard.jsx
@@ -11,6 +11,7 @@ import {
 } from "react-icons/fa";
 import { supabase } from "../../utils/supabase";
 import { useLang } from "../../LanguageContext";
+import { useTheme } from "../../ThemeContext";
 import { useTranslation } from "react-i18next";
 import "../styles/Dashboard.css";
 
@@ -22,6 +23,8 @@ export default function Dashboard() {
   const [userName, setUserName] = useState("");
   const [alertCount, setAlertCount] = useState(0);
   const { lang, toggleLang } = useLang();
+  const { toggleDark } = useTheme();
+  const [search, setSearch] = useState("");
   const { t } = useTranslation();
   useEffect(() => {
     async function loadData() {
@@ -80,7 +83,19 @@ export default function Dashboard() {
               </li>
             </ul>
         </div>
+        <div className="navbar-center">
+          <input
+            type="text"
+            className="search-input"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder={t('search_placeholder')}
+          />
+        </div>
         <div className="navbar-right">
+          <button onClick={toggleDark} className="dark-btn" title="Toggle dark mode">
+            🌙
+          </button>
           <button onClick={toggleLang} className="lang-btn">
             {t('lang_button')}
           </button>

--- a/frontend/src/presentation/styles/Dashboard.css
+++ b/frontend/src/presentation/styles/Dashboard.css
@@ -25,6 +25,20 @@
   display: flex;
   justify-content: center;
 }
+.search-input {
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  min-width: 180px;
+}
+.dark-btn {
+  background: transparent;
+  border: 1px solid #fff;
+  color: #fff;
+  padding: 2px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
 .dashboard-logo {
   font-weight: bold;
   font-size: 1.3rem;
@@ -348,4 +362,30 @@
     flex: 1 0 auto;
     justify-content: flex-end;
   }
+}
+
+/* Dark mode styles */
+body.dark .dashboard-root {
+  background: #2b2b2b;
+  color: #f5f5f5;
+}
+body.dark .dashboard-navbar {
+  background: #1f1f1f;
+}
+body.dark .dashboard-panel,
+body.dark .dashboard-activity,
+body.dark .dashboard-stats .stat,
+body.dark .dashboard-progress-bar {
+  background: #333;
+  color: #f5f5f5;
+}
+body.dark .search-input {
+  background: #555;
+  border-color: #666;
+  color: #fff;
+}
+body.dark .lang-btn,
+body.dark .dark-btn {
+  border-color: #fff;
+  color: #fff;
 }


### PR DESCRIPTION
## Summary
- add ThemeContext for dark mode
- wrap application in ThemeProvider
- add search box and dark mode toggle in dashboard navbar
- implement styles and translations for new features

## Testing
- `npm test --silent --runTestsByPath src/App.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687590dd90fc832b970e88fbd650af67