### PR TITLE
Improve dashboard search

### DIFF
--- a/frontend/src/presentation/pages/Dashboard.jsx
+++ b/frontend/src/presentation/pages/Dashboard.jsx
@@ -28,6 +28,7 @@ export default function Dashboard() {
   const { lang, toggleLang } = useLang();
   const { toggleDark } = useTheme();
   const [search, setSearch] = useState("");
+  const [results, setResults] = useState([]);
   const { t } = useTranslation();
   useEffect(() => {
     async function loadData() {
@@ -52,6 +53,48 @@ export default function Dashboard() {
     }
     loadData();
   }, []);
+
+  // Available sections to search
+  const sections = [
+    {
+      name: t('dashboard_map'),
+      path: '/puntos',
+      keywords: ['mapa', 'map', 'puntos', 'mapa interactivo']
+    },
+    {
+      name: t('dashboard_register'),
+      path: '/registrar',
+      keywords: ['registrar', 'registro', 'reciclaje']
+    },
+    {
+      name: t('dashboard_rewards'),
+      path: '/recompensas',
+      keywords: ['recompensas', 'rewards', 'premios']
+    },
+    {
+      name: t('dashboard_help'),
+      path: '/ayuda',
+      keywords: ['ayuda', 'help', 'soporte', 'contacto']
+    },
+    {
+      name: t('dashboard_reports'),
+      path: '/reportes',
+      keywords: ['reportes', 'reports', 'problemas']
+    }
+  ];
+
+  useEffect(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) {
+      setResults([]);
+      return;
+    }
+    const filtered = sections.filter(s =>
+      s.name.toLowerCase().includes(query) ||
+      s.keywords.some(k => k.toLowerCase().includes(query))
+    );
+    setResults(filtered);
+  }, [search, lang]);
 
   return (
     <div className="dashboard-root">
@@ -96,6 +139,15 @@ export default function Dashboard() {
               onChange={e => setSearch(e.target.value)}
               placeholder={t('search_placeholder')}
             />
+            {results.length > 0 && (
+              <ul className="search-results">
+                {results.map(r => (
+                  <li key={r.path} onMouseDown={() => navigate(r.path)}>
+                    {r.name}
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         </div>
         <div className="navbar-right">

--- a/frontend/src/presentation/styles/Dashboard.css
+++ b/frontend/src/presentation/styles/Dashboard.css
@@ -32,6 +32,7 @@
   border: 1px solid #ccc;
   border-radius: 18px;
   padding: 2px 8px;
+  position: relative;
 }
 .search-icon {
   color: #888;
@@ -44,6 +45,26 @@
   background: transparent;
   padding: 6px;
   min-width: 180px;
+}
+.search-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  list-style: none;
+  padding: 0;
+  margin: 4px 0 0 0;
+  z-index: 10;
+}
+.search-results li {
+  padding: 6px 10px;
+  cursor: pointer;
+}
+.search-results li:hover {
+  background: #f0f0f0;
 }
 .dark-btn {
   background: transparent;
@@ -407,4 +428,11 @@ body.dark .lang-btn,
 body.dark .dark-btn {
   border-color: #fff;
   color: #fff;
+}
+body.dark .search-results {
+  background: #555;
+  border-color: #666;
+}
+body.dark .search-results li:hover {
+  background: #666;
 }


### PR DESCRIPTION
## Summary
- implement keyword-based search on dashboard page
- show filtered sections list in search dropdown
- style search dropdown and add dark mode styling

## Testing
- `npm test --silent -- -w 1`

------
https://chatgpt.com/codex/tasks/task_e_6875951b13d8832b9cf6e267eaef8bd6