### PR TITLE
Enable dark mode on several pages

### DIFF
--- a/frontend/src/presentation/styles/HelpCenter.css
+++ b/frontend/src/presentation/styles/HelpCenter.css
@@ -373,3 +373,49 @@ body {
   }
 }
 
+/* Dark mode styles */
+body.dark .help-center-bg {
+  background: #2b2b2b;
+  color: #f0f0f0;
+}
+body.dark .help-center-container {
+  background: #2b2b2b;
+}
+body.dark .help-header {
+  background: #1f1f1f;
+}
+body.dark .help-search-wrapper {
+  background: #555;
+}
+body.dark .help-search {
+  color: #fff;
+}
+body.dark .help-title,
+body.dark .help-card__title,
+body.dark .help-faq-title,
+body.dark .help-contact-hours-title {
+  color: #8ab4f8;
+}
+body.dark .help-card,
+body.dark .help-faq-list,
+body.dark .help-form,
+body.dark .help-contact {
+  background: #333;
+  color: #f0f0f0;
+}
+body.dark .help-faq-answer {
+  background: #444;
+  color: #fff;
+}
+body.dark .help-form select,
+body.dark .help-form input,
+body.dark .help-form textarea {
+  background: #444;
+  border-color: #666;
+  color: #fff;
+}
+body.dark .help-form-clear {
+  background: #666;
+  color: #fff;
+}
+

--- a/frontend/src/presentation/styles/Recompensas.css
+++ b/frontend/src/presentation/styles/Recompensas.css
@@ -143,3 +143,31 @@
 }
 .canje-tipo.cafe { color: #fd7b1f; }
 .canje-tipo.libros { color: #34a5fd; }
+
+/* Dark mode styles */
+body.dark .recompensas-root {
+  background: #1f1f1f;
+  color: #f0f0f0;
+}
+body.dark .recompensas-header {
+  background: #333;
+}
+body.dark .recompensas-puntos {
+  background: #555;
+  color: #fd7b1f;
+}
+body.dark .categoria {
+  background: #333;
+  color: #fd7b1f;
+}
+body.dark .categoria.selected {
+  background: #fd7b1f;
+  color: #fff;
+}
+body.dark .pop-card {
+  background: #444;
+  color: #f0f0f0;
+}
+body.dark .recompensas-recientes {
+  background: #444;
+}

--- a/frontend/src/presentation/styles/RegisterRecyclePage.module.css
+++ b/frontend/src/presentation/styles/RegisterRecyclePage.module.css
@@ -282,3 +282,33 @@
   transition: background .18s;
 }
 .confirmBtn:hover { background: #228c39; }
+
+/* Dark mode styles */
+:global(body.dark) .pageBg {
+  background: #2b2b2b;
+}
+:global(body.dark) .formWrap {
+  background: #333;
+  color: #f5f5f5;
+}
+:global(body.dark) .headerBar {
+  background: #1f1f1f;
+  color: #fff;
+}
+:global(body.dark) .pointBox {
+  background: #333;
+  border-color: #555;
+}
+:global(body.dark) .materialCard {
+  background: #333;
+  border-color: #555;
+}
+:global(body.dark) .summaryBox {
+  background: #444;
+  border-color: #555;
+}
+:global(body.dark) .obsInput {
+  background: #444;
+  border-color: #666;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- update Recompensas styles for dark mode
- update Help Center styles for dark mode
- add dark theme rules for Register Recycle page

## Testing
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_687595fc5504832bba45c34397e18abc