### PR TITLE
Update Reportes header

### DIFF
--- a/frontend/src/presentation/pages/Reportes.jsx
+++ b/frontend/src/presentation/pages/Reportes.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import "../styles/Reportes.css";
 
 const incidentTypes = [
@@ -33,6 +34,7 @@ const incidentTypes = [
 ];
 
 export default function Reportes() {
+  const navigate = useNavigate();
   const [selectedType, setSelectedType] = useState("damaged");
   const [location, setLocation] = useState("Biblioteca Central");
   const [description, setDescription] = useState("");
@@ -47,13 +49,19 @@ export default function Reportes() {
   };
 
   return (
-    <div className="incident-container">
-      <header className="incident-header">
-        <span>Ayuda &gt; Reportar Incidente</span>
+    <div className="reportes-root">
+      <header className="reportes-header">
+        <button
+          className="back-btn"
+          onClick={() => navigate(-1)}
+          aria-label="Volver"
+        >
+          ←
+        </button>
         <button className="urgent-btn">Reporte Urgente</button>
       </header>
-
-      <h2 className="incident-title">Reportar Incidente o Problema</h2>
+      <div className="incident-container">
+        <h2 className="incident-title">Reportar Incidente o Problema</h2>
       
       <section>
         <h3 className="section-title">Selecciona el Tipo de Incidente</h3>
@@ -157,6 +165,7 @@ export default function Reportes() {
       <div className="incident-footer">
         <button className="cancel-btn">Cancelar</button>
         <button className="send-btn">Enviar Reporte</button>
+      </div>
       </div>
     </div>
   );

--- a/frontend/src/presentation/styles/Reportes.css
+++ b/frontend/src/presentation/styles/Reportes.css
@@ -1,3 +1,28 @@
+.reportes-root {
+  background: #ececec;
+  min-height: 100vh;
+  font-family: 'Segoe UI', Arial, sans-serif;
+}
+
+.reportes-header {
+  background: #ff6d2d;
+  color: #fff;
+  padding: 16px 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 0 0 16px 16px;
+}
+
+.back-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.2rem;
+  cursor: pointer;
+  margin-right: 8px;
+}
+
 .incident-container {
   background: #fff;
   max-width: 550px;
@@ -5,19 +30,10 @@
   border-radius: 18px;
   box-shadow: 0 4px 32px rgba(0,0,0,0.10);
   padding: 28px 26px 24px 26px;
-  font-family: 'Segoe UI', Arial, sans-serif;
   color: #242424;
   position: relative;
 }
 
-.incident-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  color: #89bedc;
-  font-size: 1rem;
-  margin-bottom: 8px;
-}
 
 .urgent-btn {
   background: #ff765b;


### PR DESCRIPTION
## Summary
- add navigate hook to Reportes page
- create responsive red header with a back button
- style header and root container in Reportes CSS

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68759815fbe0832b987b24383627aa69