### PR TITLE
Enhance reports page layout with confirmation modal

### DIFF
--- a/frontend/src/presentation/components/ReportConfirmModal.jsx
+++ b/frontend/src/presentation/components/ReportConfirmModal.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import styles from "./ReportConfirmModal.module.css";
+
+export default function ReportConfirmModal({ data, onCancel, onConfirm }) {
+  return (
+    <div className={styles.bg} role="dialog" aria-modal="true">
+      <div className={styles.card}>
+        <h3 className={styles.title}>Confirmar Envío</h3>
+        <p className={styles.message}>¿Deseas enviar este reporte?</p>
+        <div className={styles.summary}>
+          <div>
+            <b>Tipo:</b> {data.type}
+          </div>
+          <div>
+            <b>Ubicación:</b> {data.location}
+          </div>
+          <div>
+            <b>Severidad:</b> {data.urgency}
+          </div>
+          <div>
+            <b>Descripción:</b> {data.description || "(No ingresada)"}
+          </div>
+        </div>
+        <div className={styles.actions}>
+          <button type="button" className={styles.cancelBtn} onClick={onCancel}>
+            Cancelar
+          </button>
+          <button type="button" className={styles.confirmBtn} onClick={onConfirm}>
+            Enviar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/presentation/components/ReportConfirmModal.module.css
+++ b/frontend/src/presentation/components/ReportConfirmModal.module.css
@@ -1,0 +1,65 @@
+.bg {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 3200;
+}
+
+.card {
+  background: #fff;
+  border-radius: 10px;
+  padding: 24px;
+  width: 360px;
+  max-width: 90vw;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.title {
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-size: 1.2rem;
+  text-align: center;
+  color: #2e4254;
+}
+
+.message {
+  margin-bottom: 12px;
+  text-align: center;
+  color: #444;
+}
+
+.summary {
+  font-size: 0.95rem;
+  color: #555;
+  margin-bottom: 18px;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.cancelBtn {
+  background: #bbb;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+
+.confirmBtn {
+  background: #ff6d2d;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 16px;
+  cursor: pointer;
+}

--- a/frontend/src/presentation/pages/Reportes.jsx
+++ b/frontend/src/presentation/pages/Reportes.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import ReportConfirmModal from "../components/ReportConfirmModal";
 import { useNavigate } from "react-router-dom";
 import "../styles/Reportes.css";
 
@@ -43,9 +44,19 @@ export default function Reportes() {
   const [file, setFile] = useState(null);
   const [email, setEmail] = useState("gsa.problemas@uleam.edu.ec");
   const [phone, setPhone] = useState("+57 300 123 4567");
+  const [showConfirm, setShowConfirm] = useState(false);
 
   const handleFileChange = (e) => {
     setFile(e.target.files[0]);
+  };
+
+  const handleSend = () => {
+    setShowConfirm(true);
+  };
+
+  const handleConfirm = () => {
+    alert("Reporte enviado");
+    setShowConfirm(false);
   };
 
   return (
@@ -164,9 +175,21 @@ export default function Reportes() {
 
       <div className="incident-footer">
         <button className="cancel-btn">Cancelar</button>
-        <button className="send-btn">Enviar Reporte</button>
+        <button className="send-btn" onClick={handleSend}>Enviar Reporte</button>
       </div>
       </div>
+      {showConfirm && (
+        <ReportConfirmModal
+          data={{
+            type: incidentTypes.find((x) => x.key === selectedType).title,
+            location,
+            urgency,
+            description,
+          }}
+          onCancel={() => setShowConfirm(false)}
+          onConfirm={handleConfirm}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/presentation/styles/Reportes.css
+++ b/frontend/src/presentation/styles/Reportes.css
@@ -215,7 +215,9 @@ label {
 @media (max-width: 650px) {
   .incident-container {
     padding: 10px 2vw;
-    max-width: 99vw;
+    max-width: 100%;
+    margin: 0;
+    border-radius: 0;
   }
   .incident-types {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- add `ReportConfirmModal` component for sending reports
- show modal on "Enviar Reporte" to confirm
- tweak responsive CSS for reports page so the form fits small screens

## Testing
- `npm test --silent --runTestsByPath src/App.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68759b3f3ad8832b808bfb8345cde519