### PR TITLE
Replace emoji with FontAwesome icons

### DIFF
--- a/frontend/src/presentation/components/RecycleHistory.jsx
+++ b/frontend/src/presentation/components/RecycleHistory.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { supabase } from "../../utils/supabase";
+import { FaTrash, FaClipboard } from "react-icons/fa";
 import DeleteConfirm from "./DeleteConfirm";
 import "../styles/RecycleHistory.css";
 
@@ -59,9 +60,11 @@ const RecycleHistory = () => {
                 onClick={() => setToDelete(rec)}
                 aria-label="Eliminar registro"
               >
-                🗑️
+                <FaTrash />
               </button>
-              <div className="record-icon">&#128230;</div>
+              <div className="record-icon">
+                <FaClipboard />
+              </div>
               <div className="record-info">
                 <div className="record-date">
                   <b>{new Date(rec.fecha).toLocaleDateString()}</b>

--- a/frontend/src/presentation/components/UserProfile.jsx
+++ b/frontend/src/presentation/components/UserProfile.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { FaEdit, FaCog } from "react-icons/fa";
 import { supabase } from "../../utils/supabase";
 import "../styles/UserProfile.css";
 
@@ -48,9 +49,9 @@ const UserProfile = () => {
           <span className="profile-title">Mi Perfil</span>
           <div className="profile-actions">
             <button className="edit-btn" onClick={() => navigate('/perfil#editar')}>
-              <span className="edit-icon">&#9998;</span> Editar Perfil
+              <FaEdit className="edit-icon" /> Editar Perfil
             </button>
-            <span className="settings-icon">&#9881;</span>
+            <FaCog className="settings-icon" />
           </div>
         </div>
         <div className="profile-content">


### PR DESCRIPTION
## Summary
- switch user profile icons from HTML emoji to FontAwesome
- use FontAwesome icons for recycle history actions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68759c4fde44832b91ebb59d082d851c