### PR TITLE
Aumentar ancho de la sección de incidentes

### DIFF
--- a/frontend/src/presentation/styles/Reportes.css
+++ b/frontend/src/presentation/styles/Reportes.css
@@ -25,7 +25,7 @@
 
 .incident-container {
   background: #fff;
-  max-width: 550px;
+  max-width: 800px;
   margin: 30px auto;
   border-radius: 18px;
   box-shadow: 0 4px 32px rgba(0,0,0,0.10);


### PR DESCRIPTION
## Summary
- widen incident report container to 800px for better readability

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68759ebd0c68832b9aeadcaaf961d2aa